### PR TITLE
Update LegitimacyCheck.js

### DIFF
--- a/LegitimacyCheck.js
+++ b/LegitimacyCheck.js
@@ -12,7 +12,7 @@ module.exports = (host) => {
   let inviteCheckConfig = {
       protocol: 'https',
       host: host,
-      path: '/assess_me',
+      path: '/assess_me/',
       successMsg: `${host} to be assessed`,
       failureMsg: `${host} should not be assessed`,
       expectedContent: host


### PR DESCRIPTION
When the path is '/assess_me', a lot of users including myself get a 301 redirect (to '/assess_me/' with the trailing slash) causing an error, and a failure of the assessment. Changing the path to '/assess_me/' (with a trailing slash) seems to fix the issue.